### PR TITLE
Collapse wikipedia/zillow hard coded links into generalized link type

### DIFF
--- a/src/popup-generation/FieldInputRow.js
+++ b/src/popup-generation/FieldInputRow.js
@@ -5,19 +5,14 @@ import {FIELD_TYPES} from "./constants";
 const calculateUIInfo = (fieldType) => {
 	switch(fieldType) {
 		case FIELD_TYPES.text:
-			return {
-				showFieldName: true,
-				fieldDisplayNameLabel: 'Field Display Name',
-			}
 		case FIELD_TYPES.number:
 			return {
-				showFieldName: true,
 				fieldDisplayNameLabel: 'Field Display Name',
 			}
-		case FIELD_TYPES.zillowLink:
-			return {}
-		case FIELD_TYPES.wikipediaLink:
-			return {}
+		case FIELD_TYPES.link:
+			return {
+				fieldDisplayNameLabel: 'Link Text',
+			}
 		case FIELD_TYPES.subSectionHeader:
 			return {
 				fieldDisplayNameLabel: 'Header Text',
@@ -29,20 +24,21 @@ const calculateUIInfo = (fieldType) => {
 }
 
 export const FieldInputRow = ({index, fieldInputValue, onChange, onDeleteField}) => {
-	const {showFieldName, fieldDisplayNameLabel} = calculateUIInfo(fieldInputValue.fieldType)
+	const {fieldDisplayNameLabel} = calculateUIInfo(fieldInputValue.fieldType)
+	const isNotSubSectionHeader = fieldInputValue.fieldType !== FIELD_TYPES.subSectionHeader
+	const isLink = fieldInputValue.fieldType === FIELD_TYPES.link
 	return (
 		<div className="field-input-container" style={{display: 'flex'}}>
-			{fieldDisplayNameLabel && <Input
+			<Input
 				style={{flex: 2}}
 				addonBefore={fieldDisplayNameLabel}
 				value={fieldInputValue.fieldDisplayName}
 				onChange={({target}) => onChange({...fieldInputValue, fieldDisplayName: target.value})}
-			/>}
+			/>
 			
-			{showFieldName && <Input
+			{isNotSubSectionHeader && <Input
 				style={{flex: 2}}
-				addonBefore="CARTO Field"
-				placeholer={"eg state_pop_2018"}
+				addonBefore={isLink ? 'URL' : 'CARTO Field'}
 				value={fieldInputValue.fieldName}
 				onChange={({target}) => onChange({...fieldInputValue, fieldName: target.value.trim()})}
 			/>}
@@ -53,11 +49,8 @@ export const FieldInputRow = ({index, fieldInputValue, onChange, onDeleteField})
 				className="field-type"
 				onChange={(fieldType) => onChange({...fieldInputValue, fieldType})}
 			>
-				<Select.Option value={FIELD_TYPES.number}>{FIELD_TYPES.number}</Select.Option>
-				<Select.Option value={FIELD_TYPES.text}>{FIELD_TYPES.text}</Select.Option>
-				<Select.Option value={FIELD_TYPES.zillowLink}>{FIELD_TYPES.zillowLink}</Select.Option>
-				<Select.Option value={FIELD_TYPES.wikipediaLink}>{FIELD_TYPES.wikipediaLink}</Select.Option>
-				<Select.Option value={FIELD_TYPES.subSectionHeader}>{FIELD_TYPES.subSectionHeader}</Select.Option>
+				{Object.values(FIELD_TYPES).map(fieldType => <Select.Option key={fieldType} value={fieldType}>{fieldType}</Select.Option>)}
+				
 			</Select>
 			<Button className="delete-button" onClick={() => onDeleteField(index)} danger>X</Button>
 		</div>

--- a/src/popup-generation/constants.js
+++ b/src/popup-generation/constants.js
@@ -1,8 +1,7 @@
 export const FIELD_TYPES = {
 	number: 'Number',
 	text: 'Text',
-	zillowLink: 'Zillow Foreclosures Link',
-	wikipediaLink: 'Wikipedia Link',
+	link: 'Link',
 	subSectionHeader: 'Sub Section Header'
 }
 
@@ -24,12 +23,16 @@ export const DEFAULT_INPUT_VALUES = [
 	
 	// Wikipedia Link
 	{
-		fieldType: FIELD_TYPES.wikipediaLink,
+		fieldType: FIELD_TYPES.link,
+		fieldDisplayName: 'Wikipedia',
+		fieldName: 'https://en.wikipedia.org/wiki/{{county_name}},_{{stusps}}'
 	},
 	
 	// Foreclosed Houses on Zillow
 	{
-		fieldType: FIELD_TYPES.zillowLink,
+		fieldType: FIELD_TYPES.link,
+		fieldDisplayName: 'Zillow Forclosures',
+		fieldName: 'https://www.zillow.com/{{county_name}}-{{stusps}}/foreclosures/'
 	},
 	
 	// Contractor Link (if applicable)

--- a/src/popup-generation/htmlGenerators.js
+++ b/src/popup-generation/htmlGenerators.js
@@ -29,10 +29,6 @@ const link = (url, text) => `
 	</div>
 `
 
-const zillowLink = () => link('https://www.zillow.com/{{county_name}}-{{stusps}}/foreclosures/', 'Foreclosures on Zillow')
-
-const wikipediaLink = () => link('https://en.wikipedia.org/wiki/{{county_name}},_{{stusps}}', 'Wikipedia')
-
 const subSectionHeader = headerText => textComponent(headerText, true, true)
 
 const fieldContent = ({fieldName, fieldDisplayName, fieldType}) => {
@@ -41,10 +37,8 @@ const fieldContent = ({fieldName, fieldDisplayName, fieldType}) => {
 			return textOrNumberContent(fieldName, fieldDisplayName, true)
 		case FIELD_TYPES.number:
 			return textOrNumberContent(fieldName, fieldDisplayName)
-		case FIELD_TYPES.zillowLink:
-			return zillowLink()
-		case FIELD_TYPES.wikipediaLink:
-			return wikipediaLink()
+		case FIELD_TYPES.link:
+			return link(fieldName, fieldDisplayName)
 		case FIELD_TYPES.subSectionHeader:
 			return subSectionHeader(fieldDisplayName)
 		default:


### PR DESCRIPTION
Now, you should be able to specify any link text and URL under type `Link` in the UI. Zillow and Wiki link types are gone now.

## How to test
0. Switch to branch, then add a new test link field
1. Copy the HTML
2. Paste it in [this FM test map](https://fanniemae.carto.com/u/cori-fm/builder/0620b73b-3e66-4e4b-94d9-040e3e3756db/layer/2d9286f5-d50e-4306-ab80-f101734db99b/popups)